### PR TITLE
Fix #7: fallback to non-streaming when streaming crashes

### DIFF
--- a/frontend/Document_QA.py
+++ b/frontend/Document_QA.py
@@ -68,7 +68,16 @@ def chatbox():
                 if response is None:
                     st.write("Couldn't come up with an answer.")
                 else:
-                    response_text = st.write_stream(response.response_gen)
+                    try:
+                        response_text = st.write_stream(response.response_gen)
+                    except TypeError as e:
+                        st.warning("Streaming failed due to Ollama/LlamaIndex token count issue. Falling back to non-streaming output.")
+                        response_text = str(response)
+                        st.write(response_text)
+                    except Exception as e:
+                        st.warning(f"Streaming failed: {e}. Falling back to non-streaming output.")
+                        response_text = str(response)
+                        st.write(response_text)
                     st.write(f"Took {query_time} second(s)")
                     details_title = f"Found {len(response.source_nodes)} document(s)"
                     with st.expander(


### PR DESCRIPTION
Problem: Document QA streaming (st.write_stream(response.response_gen)) may crash with a TypeError in the Ollama/LlamaIndex stack (token count fields can be None), causing the whole Streamlit page to fail.

Fix: Wrap streaming output in try/except. If streaming fails, show a warning and fall back to non-streaming output (str(response)) so the app remains usable.